### PR TITLE
Renames functions with underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
-- Changes the names of FFI'd timer functions to avoid naming clashes.
+- Changes the names of FFI timer functions to avoid naming clashes (#29 by @mikesol)
 
 Other improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Changes the names of FFI'd timer functions to avoid naming clashes.
 
 Other improvements:
 

--- a/src/Effect/Timer.js
+++ b/src/Effect/Timer.js
@@ -1,5 +1,5 @@
 /* no-redeclare global exports */
-export function setTimeout(ms) {
+export function setTimeout_(ms) {
   return function (fn) {
     return function () {
       return setTimeout(fn, ms);
@@ -7,13 +7,13 @@ export function setTimeout(ms) {
   };
 }
 
-export function clearTimeout(id) {
+export function clearTimeout_(id) {
   return function () {
     clearTimeout(id);
   };
 }
 
-export function setInterval(ms) {
+export function setInterval_(ms) {
   return function (fn) {
     return function () {
       return setInterval(fn, ms);
@@ -21,7 +21,7 @@ export function setInterval(ms) {
   };
 }
 
-export function clearInterval(id) {
+export function clearInterval_(id) {
   return function () {
     clearInterval(id);
   };

--- a/src/Effect/Timer.js
+++ b/src/Effect/Timer.js
@@ -1,5 +1,5 @@
 /* no-redeclare global exports */
-export function setTimeout_(ms) {
+export function setTimeoutImpl(ms) {
   return function (fn) {
     return function () {
       return setTimeout(fn, ms);
@@ -7,13 +7,13 @@ export function setTimeout_(ms) {
   };
 }
 
-export function clearTimeout_(id) {
+export function clearTimeoutImpl(id) {
   return function () {
     clearTimeout(id);
   };
 }
 
-export function setInterval_(ms) {
+export function setIntervalImpl(ms) {
   return function (fn) {
     return function () {
       return setInterval(fn, ms);
@@ -21,7 +21,7 @@ export function setInterval_(ms) {
   };
 }
 
-export function clearInterval_(id) {
+export function clearIntervalImpl(id) {
   return function () {
     clearInterval(id);
   };

--- a/src/Effect/Timer.purs
+++ b/src/Effect/Timer.purs
@@ -18,6 +18,7 @@ derive instance eqTimeoutId :: Eq TimeoutId
 derive instance ordTimeoutId :: Ord TimeoutId
 
 foreign import setTimeoutImpl :: Int -> Effect Unit -> Effect TimeoutId
+
 -- | Runs an effectful function after the specified delay in milliseconds. The
 -- | returned `TimeoutId` can be used to cancel the timer before it completes.
 -- |
@@ -27,10 +28,12 @@ setTimeout :: Int -> Effect Unit -> Effect TimeoutId
 setTimeout = setTimeoutImpl
 
 foreign import clearTimeoutImpl :: TimeoutId -> Effect Unit
+
 -- | Cancels a timeout. If the timeout has already been cancelled or has already
 -- | elapsed this will have no effect.
 clearTimeout :: TimeoutId -> Effect Unit
 clearTimeout = clearTimeoutImpl
+
 -- | The ID of a timer started with `setInterval`.
 newtype IntervalId = IntervalId Int
 
@@ -38,6 +41,7 @@ derive instance eqIntervalId :: Eq IntervalId
 derive instance ordIntervalId :: Ord IntervalId
 
 foreign import setIntervalImpl :: Int -> Effect Unit -> Effect IntervalId
+
 -- | Runs an effectful function after on a set interval with the specified delay
 -- | in milliseconds between iterations. The returned `IntervalId` can be used
 -- | to cancel the timer and prevent the interval from running any further.
@@ -48,6 +52,7 @@ setInterval :: Int -> Effect Unit -> Effect IntervalId
 setInterval = setIntervalImpl
 
 foreign import clearIntervalImpl :: IntervalId -> Effect Unit
+
 -- | Cancels an interval timer. If the interval has already been cancelled this
 -- | will have no effect.
 clearInterval :: IntervalId -> Effect Unit

--- a/src/Effect/Timer.purs
+++ b/src/Effect/Timer.purs
@@ -22,12 +22,15 @@ derive instance ordTimeoutId :: Ord TimeoutId
 -- |
 -- | The timeout delay value is capped at 4ms by the JS API, any value less than
 -- | this will be clamped.
-foreign import setTimeout :: Int -> Effect Unit -> Effect TimeoutId
+setTimeout :: Int -> Effect Unit -> Effect TimeoutId
+setTimeout = setTimeout_
+foreign import setTimeout_ :: Int -> Effect Unit -> Effect TimeoutId
 
 -- | Cancels a timeout. If the timeout has already been cancelled or has already
 -- | elapsed this will have no effect.
-foreign import clearTimeout :: TimeoutId -> Effect Unit
-
+clearTimeout :: TimeoutId -> Effect Unit
+clearTimeout = clearTimeout_
+foreign import clearTimeout_ :: TimeoutId -> Effect Unit
 -- | The ID of a timer started with `setInterval`.
 newtype IntervalId = IntervalId Int
 
@@ -40,8 +43,12 @@ derive instance ordIntervalId :: Ord IntervalId
 -- |
 -- | The interval delay value is capped at 4ms by the JS API, any value less
 -- | than this will be clamped.
-foreign import setInterval :: Int -> Effect Unit -> Effect IntervalId
+setInterval :: Int -> Effect Unit -> Effect IntervalId
+setInterval = setInterval_
+foreign import setInterval_ :: Int -> Effect Unit -> Effect IntervalId
 
 -- | Cancels an interval timer. If the interval has already been cancelled this
 -- | will have no effect.
-foreign import clearInterval :: IntervalId -> Effect Unit
+clearInterval :: IntervalId -> Effect Unit
+clearInterval = clearInterval_
+foreign import clearInterval_ :: IntervalId -> Effect Unit

--- a/src/Effect/Timer.purs
+++ b/src/Effect/Timer.purs
@@ -17,26 +17,27 @@ newtype TimeoutId = TimeoutId Int
 derive instance eqTimeoutId :: Eq TimeoutId
 derive instance ordTimeoutId :: Ord TimeoutId
 
+foreign import setTimeoutImpl :: Int -> Effect Unit -> Effect TimeoutId
 -- | Runs an effectful function after the specified delay in milliseconds. The
 -- | returned `TimeoutId` can be used to cancel the timer before it completes.
 -- |
 -- | The timeout delay value is capped at 4ms by the JS API, any value less than
 -- | this will be clamped.
 setTimeout :: Int -> Effect Unit -> Effect TimeoutId
-setTimeout = setTimeout_
-foreign import setTimeout_ :: Int -> Effect Unit -> Effect TimeoutId
+setTimeout = setTimeoutImpl
 
+foreign import clearTimeoutImpl :: TimeoutId -> Effect Unit
 -- | Cancels a timeout. If the timeout has already been cancelled or has already
 -- | elapsed this will have no effect.
 clearTimeout :: TimeoutId -> Effect Unit
-clearTimeout = clearTimeout_
-foreign import clearTimeout_ :: TimeoutId -> Effect Unit
+clearTimeout = clearTimeoutImpl
 -- | The ID of a timer started with `setInterval`.
 newtype IntervalId = IntervalId Int
 
 derive instance eqIntervalId :: Eq IntervalId
 derive instance ordIntervalId :: Ord IntervalId
 
+foreign import setIntervalImpl :: Int -> Effect Unit -> Effect IntervalId
 -- | Runs an effectful function after on a set interval with the specified delay
 -- | in milliseconds between iterations. The returned `IntervalId` can be used
 -- | to cancel the timer and prevent the interval from running any further.
@@ -44,11 +45,10 @@ derive instance ordIntervalId :: Ord IntervalId
 -- | The interval delay value is capped at 4ms by the JS API, any value less
 -- | than this will be clamped.
 setInterval :: Int -> Effect Unit -> Effect IntervalId
-setInterval = setInterval_
-foreign import setInterval_ :: Int -> Effect Unit -> Effect IntervalId
+setInterval = setIntervalImpl
 
+foreign import clearIntervalImpl :: IntervalId -> Effect Unit
 -- | Cancels an interval timer. If the interval has already been cancelled this
 -- | will have no effect.
 clearInterval :: IntervalId -> Effect Unit
-clearInterval = clearInterval_
-foreign import clearInterval_ :: IntervalId -> Effect Unit
+clearInterval = clearIntervalImpl


### PR DESCRIPTION
**Description of the change**
---

This fixes a bug where certain bundlers rename the timer functions.

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
